### PR TITLE
Add responsive navbar with contact bar

### DIFF
--- a/wordpress/wp-content/themes/astra-child/assets/css/custom.css
+++ b/wordpress/wp-content/themes/astra-child/assets/css/custom.css
@@ -80,6 +80,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 1rem 2rem;
+  position: relative;
 }
 
 /* Menú principal */
@@ -106,4 +107,71 @@
 .nav-menu li.current-menu-item a {
   color: #8dc63f;
   font-weight: 600;
+}
+
+/* Contact info layout */
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.topbar .contact-info span {
+  margin-right: 1rem;
+}
+.topbar .social-icons a {
+  margin-left: 0.5rem;
+  color: inherit;
+  text-decoration: none;
+}
+.topbar .social-icons a:hover {
+  color: #8dc63f;
+}
+
+/* Menu toggle */
+.menu-toggle {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.menu-toggle .hamburger,
+.menu-toggle .hamburger::before,
+.menu-toggle .hamburger::after {
+  display: block;
+  width: 24px;
+  height: 3px;
+  background-color: #1c347f;
+  position: relative;
+  transition: all 0.3s ease;
+}
+.menu-toggle .hamburger::before,
+.menu-toggle .hamburger::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+}
+.menu-toggle .hamburger::before { top: -8px; }
+.menu-toggle .hamburger::after { top: 8px; }
+
+@media (max-width: 768px) {
+  .main-navigation {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background-color: #fff;
+    width: 100%;
+    display: none;
+    padding: 1rem 2rem;
+  }
+  .main-navigation.active {
+    display: block;
+  }
+  .main-navigation .nav-menu {
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .menu-toggle {
+    display: block;
+  }
 }

--- a/wordpress/wp-content/themes/astra-child/assets/js/custom.js
+++ b/wordpress/wp-content/themes/astra-child/assets/js/custom.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var toggle = document.querySelector('.menu-toggle');
+  var nav = document.querySelector('.main-navigation');
+
+  if (toggle && nav) {
+    toggle.addEventListener('click', function () {
+      nav.classList.toggle('active');
+    });
+  }
+});

--- a/wordpress/wp-content/themes/astra-child/functions.php
+++ b/wordpress/wp-content/themes/astra-child/functions.php
@@ -17,6 +17,18 @@ function astra_child_enqueue_styles() {
         array('astra-parent-style'),
         filemtime(get_stylesheet_directory() . '/assets/css/custom.css') // cache busting dinámico
     );
+
+    // Enqueue dashicons for front-end icons
+    wp_enqueue_style('dashicons');
+
+    // Enqueue custom JavaScript for the navigation toggle
+    wp_enqueue_script(
+        'astra-child-script',
+        get_stylesheet_directory_uri() . '/assets/js/custom.js',
+        array('jquery'),
+        filemtime(get_stylesheet_directory() . '/assets/js/custom.js'),
+        true
+    );
 }
 add_action('wp_enqueue_scripts', 'astra_child_enqueue_styles');
 

--- a/wordpress/wp-content/themes/astra-child/header.php
+++ b/wordpress/wp-content/themes/astra-child/header.php
@@ -14,7 +14,15 @@
 <body <?php body_class(); ?>>
 <header class="site-header">
   <div class="topbar">
-    <!-- Email / Teléfono / Enlaces sociales -->
+    <div class="contact-info">
+      <span class="phone"><span class="dashicons dashicons-phone"></span> (800) 123-4567</span>
+      <span class="email"><span class="dashicons dashicons-email"></span> contacto@example.com</span>
+    </div>
+    <div class="social-icons">
+      <a href="#" class="social-icon" aria-label="Facebook"><span class="dashicons dashicons-facebook"></span></a>
+      <a href="#" class="social-icon" aria-label="Instagram"><span class="dashicons dashicons-instagram"></span></a>
+      <a href="#" class="social-icon" aria-label="Twitter"><span class="dashicons dashicons-twitter"></span></a>
+    </div>
   </div>
 
   <div class="navbar-wrapper">
@@ -30,6 +38,9 @@
         ));
       ?>
     </nav>
+    <button class="menu-toggle" aria-label="<?php esc_attr_e( 'Abrir menú', 'astra-child' ); ?>">
+      <span class="hamburger"></span>
+    </button>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary
- add contact info and social icons in `header.php`
- enqueue dashicons and custom script
- implement JS menu toggle
- modernize navigation styles with responsive support

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68516dc47b80832cbf21f4ef34dc92bd